### PR TITLE
FIX ios bug : You don’t have permission to save the file “Documents_t…

### DIFF
--- a/extensions/assets-manager/AssetsManagerEx.cpp
+++ b/extensions/assets-manager/AssetsManagerEx.cpp
@@ -314,7 +314,8 @@ void AssetsManagerEx::setStoragePath(const std::string& storagePath)
     _fileUtils->createDirectory(_storagePath);
     
     _tempStoragePath = _storagePath;
-    _tempStoragePath.insert(_storagePath.size() - 1, TEMP_PACKAGE_SUFFIX);
+    _tempStoragePath.insert(_storagePath.size(), TEMP_PACKAGE_SUFFIX);
+    adjustPath(_tempStoragePath);
     _fileUtils->createDirectory(_tempStoragePath);
 }
 


### PR DESCRIPTION
The iOS side, eg:Writable directory is `**/Documents/`,old code will get `**/Documents_temp/`, However, due to the sandbox mechanism of iOS, you do not have the permission of this directory, so instead fixed it to  `**/Documents/_temp/`